### PR TITLE
Implemented optional eni lookup instead of the default instance id.

### DIFF
--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -213,7 +213,7 @@ ec2ip_validate() {
 
 ec2ip_monitor() {
   MON_RES=""
-  if [ -z "${OCF_RESKEY_eni_id_lookup}" ]; then
+  if ocf_is_true ${OCF_RESKEY_eni_id_lookup}; then
     EC2_ATTRIBUTE_LOOKUP="NetworkInterfaceId"
     EC2_ID="$(ec2ip_get_instance_eni)"
     identification="interface"

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -308,7 +308,7 @@ ec2ip_get_instance_eni() {
 		return $OCF_ERR_GENERIC
 	fi
 	ocf_log debug "network interface id associated MAC address ${MAC_ADDR}: ${EC2_NETWORK_INTERFACE_ID}"
-	return $EC2_NETWORK_INTERFACE_ID
+	echo $EC2_NETWORK_INTERFACE_ID
 }
 
 ec2ip_get_and_configure() {

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -43,6 +43,7 @@ OCF_RESKEY_routing_table_default=""
 OCF_RESKEY_routing_table_role_default=""
 OCF_RESKEY_interface_default="eth0"
 OCF_RESKEY_monapi_default="false"
+OCF_RESKEY_eni_id_lookup_default="false"
 
 : ${OCF_RESKEY_awscli=${OCF_RESKEY_awscli_default}}
 : ${OCF_RESKEY_profile=${OCF_RESKEY_profile_default}}
@@ -52,6 +53,7 @@ OCF_RESKEY_monapi_default="false"
 : ${OCF_RESKEY_routing_table_role=${OCF_RESKEY_routing_table_role_default}}
 : ${OCF_RESKEY_interface=${OCF_RESKEY_interface_default}}
 : ${OCF_RESKEY_monapi=${OCF_RESKEY_monapi_default}}
+: ${OCF_RESKEY_eni_id_lookup=${OCF_RESKEY_eni_id_lookup_default}}
 #######################################################################
 
 
@@ -142,6 +144,15 @@ Enable enhanced monitoring using AWS API calls to check route table entry
 <shortdesc lang="en">Enhanced Monitoring</shortdesc>
 <content type="boolean" default="${OCF_RESKEY_monapi_default}" />
 </parameter>
+
+<parameter name="eni_id_lookup" required="0">
+<longdesc lang="en">
+Use eni id lookup instead of the default interface id method. This is useful in shared subnet setups.
+</longdesc>
+<shortdesc lang="en">Look up eni id</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_eni_id_lookup_default}" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -175,7 +186,7 @@ execute_cmd_as_role(){
 
 ec2ip_set_address_param_compat(){
 	# Include backward compatibility for the deprecated address parameter
-	if [ -z  "$OCF_RESKEY_ip" ] && [ -n "$OCF_RESKEY_address" ]; then
+	if [ -z "$OCF_RESKEY_ip" ] && [ -n "$OCF_RESKEY_address" ]; then
 		OCF_RESKEY_ip="$OCF_RESKEY_address"
 	fi
 }
@@ -201,16 +212,25 @@ ec2ip_validate() {
 }
 
 ec2ip_monitor() {
-        MON_RES=""
+  MON_RES=""
+  if [ -z "${OCF_RESKEY_eni_id_lookup}" ]; then
+    EC2_ATTRIBUTE_LOOKUP="NetworkInterfaceId"
+    EC2_ID="$(ec2ip_get_instance_eni)"
+    identification="interface"
+  else
+    EC2_ATTRIBUTE_LOOKUP="InstanceId"
+    EC2_ID="$EC2_INSTANCE_ID"
+    identification="instance"
+  fi
 	if ocf_is_true ${OCF_RESKEY_monapi} || [ "$__OCF_ACTION" = "start" ] || ocf_is_probe; then
 		for rtb in $(echo $OCF_RESKEY_routing_table | sed -e 's/,/ /g'); do
 			ocf_log info "monitor: check routing table (API call) - $rtb"
 			if [ -z "${OCF_RESKEY_routing_table_role}" ]; then
-				cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $rtb --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].InstanceId"
+				cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $rtb --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].$EC2_ATTRIBUTE_LOOKUP"
 				ocf_log debug "executing command: $cmd"
 				ROUTE_TO_INSTANCE="$($cmd)"
 			else
-				cmd="$OCF_RESKEY_awscli --output text ec2 describe-route-tables --route-table-ids $rtb --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].InstanceId"
+				cmd="$OCF_RESKEY_awscli --output text ec2 describe-route-tables --route-table-ids $rtb --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].$EC2_ATTRIBUTE_LOOKUP"
 				ROUTE_TO_INSTANCE="$(execute_cmd_as_role "$cmd" $OCF_RESKEY_routing_table_role)"
 			fi
 			ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"
@@ -218,8 +238,8 @@ ec2ip_monitor() {
 				ROUTE_TO_INSTANCE="<unknown>"
 			fi
 
-			if [ "$EC2_INSTANCE_ID" != "$ROUTE_TO_INSTANCE" ]; then 
-				ocf_log warn "not routed to this instance ($EC2_INSTANCE_ID) but to instance $ROUTE_TO_INSTANCE on $rtb"
+			if [ "$EC2_ID" != "$ROUTE_TO_INSTANCE" ]; then
+				ocf_log warn "not routed to this $identification ($EC2_ID) but to $identification $ROUTE_TO_INSTANCE on $rtb"
 				MON_RES="$MON_RES $rtb"
 			fi
 			sleep 1
@@ -263,7 +283,7 @@ ec2ip_drop() {
 	return $OCF_SUCCESS
 }
 
-ec2ip_get_and_configure() {
+ec2ip_get_instance_eni() {
 	MAC_FILE="/sys/class/net/${OCF_RESKEY_interface}/address"
 	if [ -f $MAC_FILE ]; then
 		cmd="cat ${MAC_FILE}"
@@ -288,7 +308,11 @@ ec2ip_get_and_configure() {
 		return $OCF_ERR_GENERIC
 	fi
 	ocf_log debug "network interface id associated MAC address ${MAC_ADDR}: ${EC2_NETWORK_INTERFACE_ID}"
+	return $EC2_NETWORK_INTERFACE_ID
+}
 
+ec2ip_get_and_configure() {
+  EC2_NETWORK_INTERFACE_ID="$(ec2ip_get_instance_eni)"
 	for rtb in $(echo $OCF_RESKEY_routing_table | sed -e 's/,/ /g'); do
 		if [ -z "${OCF_RESKEY_routing_table_role}" ]; then
 			cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 replace-route --route-table-id $rtb --destination-cidr-block ${OCF_RESKEY_ip}/32 --network-interface-id $EC2_NETWORK_INTERFACE_ID"
@@ -405,7 +429,7 @@ case $__OCF_ACTION in
 		ec2ip_monitor;;
 	validate-all)
 		exit $?;;
-	*)	
+	*)
 		echo $USAGE
 		exit $OCF_ERR_UNIMPLEMENTED
 		;;


### PR DESCRIPTION
In a shared network pattern where the cluster resides in shared subnets the instance ids of the nodes are not retrievable but the eni ids are and this optional feature gives transparent support in that situation.